### PR TITLE
build: add since.yaml for release automation

### DIFF
--- a/since.yaml
+++ b/since.yaml
@@ -6,6 +6,9 @@ ignore:
 
 before:
   - script: |
+      npm run lint
+      npm test
+      npm run build
       npm version "${SINCE_NEW_VERSION}" --no-git-tag-version
       git add package.json package-lock.json
 


### PR DESCRIPTION
## Summary
- Adds `since.yaml` configuration for the [since](https://github.com/release-tools/since) release tool
- Uses `npm version` to set the release version before tagging and resets to `0.0.0` afterward

## Test plan
- [x] Verify `since.yaml` is picked up by the since tool
- [x] Test a dry-run release to confirm npm version commands work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)