### PR TITLE
feat: add custom request headers panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Then open http://localhost:8080 in your browser.
 - **Response metadata** — HTTP status, response time, full response body
 - **Copy as cURL** — copy the SOAP request as a ready-to-use cURL command
 - **Inline documentation** — displays `<wsdl:documentation>` from services and operations
+- **Custom request headers** — add headers like Authorization, API keys, or WS-Security tokens to requests
 - **Base URL override** — redirect requests to a different host (e.g. localhost)
 - **Local file support** — browse and load WSDL files from your device
 - **Deep linking** — shareable URLs with `?url=` to pre-load a WSDL and `#service/endpoint/operation` to jump to a specific operation

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,8 +12,8 @@ Support `?url=...` to pre-load a WSDL and `#service/endpoint/operation` to auto-
 ### ~~2. WSDL `<documentation>` extraction and display~~ ✓
 ~~Parse `<wsdl:documentation>` elements on services, port types, and operations. Show them inline — service-level docs in the header, operation-level docs in the detail view.~~
 
-### 3. Custom request headers (including WS-Security)
-Add a headers panel — global or per-operation — where users can add key/value pairs included in requests. Covers Basic Auth, API keys, and WS-Security tokens.
+### ~~3. Custom request headers (including WS-Security)~~ ✅
+~~Add a headers panel — global or per-operation — where users can add key/value pairs included in requests. Covers Basic Auth, API keys, and WS-Security tokens.~~
 
 ### 4. SOAP Fault parsing and display
 Detect `<soap:Fault>` in responses and render them distinctly — showing faultcode, faultstring, and detail in a structured, readable format.

--- a/src/components/explorer/OperationDetail.tsx
+++ b/src/components/explorer/OperationDetail.tsx
@@ -20,6 +20,7 @@ export function OperationDetail({ operation, opKey }: OperationDetailProps) {
     setRequestXml,
     executeRequest,
     getEffectiveEndpoint,
+    getResolvedCustomHeaders,
   } = useWsdlStore()
 
   const [curlCopied, setCurlCopied] = useState(false)
@@ -41,6 +42,7 @@ export function OperationDetail({ operation, opKey }: OperationDetailProps) {
       soapAction: operation.soapAction,
       soapVersion: operation.soapVersion,
       body: state.requestXml,
+      customHeaders: getResolvedCustomHeaders(),
     })
     navigator.clipboard.writeText(curl).then(() => {
       setCurlCopied(true)

--- a/src/components/layout/HeadersPanel.tsx
+++ b/src/components/layout/HeadersPanel.tsx
@@ -1,0 +1,73 @@
+import { Plus, X, FileKey } from 'lucide-react'
+import { useWsdlStore } from '@/store/wsdl-store'
+
+export function HeadersPanel() {
+  const {
+    customHeaders,
+    addCustomHeader,
+    updateCustomHeader,
+    toggleCustomHeader,
+    removeCustomHeader,
+  } = useWsdlStore()
+
+  const enabledCount = customHeaders.filter((h) => h.enabled && h.key.trim()).length
+
+  return (
+    <div className="mt-3 rounded-xl border border-[var(--border)] bg-[var(--card)] card-shadow">
+      <div className="flex items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-3">
+          <FileKey className="h-4 w-4 text-[var(--muted-foreground)] shrink-0" />
+          <span className="text-xs font-semibold text-[var(--muted-foreground)]">
+            Custom Headers
+          </span>
+          {enabledCount > 0 && (
+            <span className="rounded-full bg-[var(--primary)]/10 px-2 py-0.5 text-[10px] font-bold text-[var(--primary)]">
+              {enabledCount}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={addCustomHeader}
+          className="flex items-center gap-1 rounded-lg border border-[var(--border)] px-2 py-1 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]"
+          title="Add header"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">Add</span>
+        </button>
+      </div>
+      {customHeaders.length > 0 && (
+        <div className="border-t border-[var(--border)] px-4 py-3 space-y-2">
+          {customHeaders.map((h) => (
+            <div key={h.id} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={h.enabled}
+                onChange={() => toggleCustomHeader(h.id)}
+                className="h-3.5 w-3.5 shrink-0 accent-[var(--primary)]"
+              />
+              <input
+                value={h.key}
+                onChange={(e) => updateCustomHeader(h.id, 'key', e.target.value)}
+                placeholder="Header name"
+                className="flex-1 min-w-0 bg-transparent font-mono text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/40 focus:outline-none border-b border-transparent focus:border-[var(--primary)]/30 py-1"
+              />
+              <input
+                value={h.value}
+                onChange={(e) => updateCustomHeader(h.id, 'value', e.target.value)}
+                placeholder="Value"
+                className="flex-1 min-w-0 bg-transparent font-mono text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/40 focus:outline-none border-b border-transparent focus:border-[var(--primary)]/30 py-1"
+              />
+              <button
+                onClick={() => removeCustomHeader(h.id)}
+                className="shrink-0 rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
+                title="Remove header"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/layout/ServiceHeader.tsx
+++ b/src/components/layout/ServiceHeader.tsx
@@ -1,6 +1,7 @@
 import type { WsdlDocument } from '@/lib/wsdl/types'
 import { useWsdlStore } from '@/store/wsdl-store'
 import { Globe } from 'lucide-react'
+import { HeadersPanel } from './HeadersPanel'
 
 interface ServiceHeaderProps {
   document: WsdlDocument
@@ -67,6 +68,7 @@ export function ServiceHeader({ document: doc }: ServiceHeaderProps) {
           </span>
         )}
       </div>
+      <HeadersPanel />
     </div>
   )
 }

--- a/src/lib/soap/curl-builder.ts
+++ b/src/lib/soap/curl-builder.ts
@@ -6,15 +6,22 @@ export interface CurlParams {
   soapAction: string
   soapVersion: SoapVersion
   body: string
+  customHeaders?: Record<string, string>
 }
 
 /**
  * Build a cURL command string for a SOAP request.
  */
 export function buildCurlCommand(params: CurlParams): string {
-  const { endpointUrl, soapAction, soapVersion, body } = params
+  const { endpointUrl, soapAction, soapVersion, body, customHeaders } = params
 
   const parts: string[] = ['curl']
+
+  if (customHeaders) {
+    for (const [name, value] of Object.entries(customHeaders)) {
+      parts.push(header(name, value))
+    }
+  }
 
   if (soapVersion === '1.1') {
     parts.push(header('Content-Type', SOAP_11_CONTENT_TYPE))

--- a/src/lib/soap/request-sender.ts
+++ b/src/lib/soap/request-sender.ts
@@ -7,7 +7,7 @@ import { SOAP_11_CONTENT_TYPE, SOAP_12_CONTENT_TYPE } from './constants'
 export async function sendSoapRequest(request: SoapRequest): Promise<SoapResponse> {
   const { endpointUrl, soapAction, soapVersion, envelopeXml } = request
 
-  const headers: Record<string, string> = {}
+  const headers: Record<string, string> = { ...request.customHeaders }
 
   if (soapVersion === '1.1') {
     headers['Content-Type'] = SOAP_11_CONTENT_TYPE

--- a/src/lib/soap/types.ts
+++ b/src/lib/soap/types.ts
@@ -1,8 +1,16 @@
+export interface CustomHeader {
+  id: string
+  key: string
+  value: string
+  enabled: boolean
+}
+
 export interface SoapRequest {
   endpointUrl: string
   soapAction: string
   soapVersion: '1.1' | '1.2'
   envelopeXml: string
+  customHeaders?: Record<string, string>
 }
 
 export interface SoapResponse {

--- a/src/store/wsdl-store.ts
+++ b/src/store/wsdl-store.ts
@@ -4,7 +4,7 @@ import { fetchAndParseWsdl, parseWsdlText, resolveOperations } from '@/lib/wsdl/
 import { buildSoapEnvelope } from '@/lib/soap/envelope-builder'
 import { sendSoapRequest } from '@/lib/soap/request-sender'
 import { generateSampleXml } from '@/lib/wsdl/xsd-utils'
-import type { SoapResponse } from '@/lib/soap/types'
+import type { SoapResponse, CustomHeader } from '@/lib/soap/types'
 
 export interface OperationRequestState {
   requestXml: string
@@ -41,6 +41,14 @@ interface WsdlStore {
   expandedOperations: Set<string>
   toggleOperation: (id: string) => void
   expandOperation: (id: string) => void
+
+  // Custom headers (global)
+  customHeaders: CustomHeader[]
+  addCustomHeader: () => void
+  updateCustomHeader: (id: string, field: 'key' | 'value', value: string) => void
+  toggleCustomHeader: (id: string) => void
+  removeCustomHeader: (id: string) => void
+  getResolvedCustomHeaders: () => Record<string, string>
 
   // Per-operation request state
   requestStates: Record<string, OperationRequestState>
@@ -165,6 +173,36 @@ export const useWsdlStore = create<WsdlStore>((set, get) => ({
       return { expandedOperations: next }
     }),
 
+  customHeaders: [],
+  addCustomHeader: () =>
+    set((state) => ({
+      customHeaders: [
+        ...state.customHeaders,
+        { id: crypto.randomUUID(), key: '', value: '', enabled: true },
+      ],
+    })),
+  updateCustomHeader: (id, field, value) =>
+    set((state) => ({
+      customHeaders: state.customHeaders.map((h) =>
+        h.id === id ? { ...h, [field]: value } : h
+      ),
+    })),
+  toggleCustomHeader: (id) =>
+    set((state) => ({
+      customHeaders: state.customHeaders.map((h) =>
+        h.id === id ? { ...h, enabled: !h.enabled } : h
+      ),
+    })),
+  removeCustomHeader: (id) =>
+    set((state) => ({
+      customHeaders: state.customHeaders.filter((h) => h.id !== id),
+    })),
+  getResolvedCustomHeaders: () => {
+    return get().customHeaders
+      .filter((h) => h.enabled && h.key.trim())
+      .reduce((acc, h) => ({ ...acc, [h.key.trim()]: h.value }), {} as Record<string, string>)
+  },
+
   requestStates: {},
 
   getOrCreateRequestState: (opKey, op) => {
@@ -217,6 +255,7 @@ export const useWsdlStore = create<WsdlStore>((set, get) => ({
         soapAction: op.soapAction,
         soapVersion: op.soapVersion,
         envelopeXml: reqState.requestXml,
+        customHeaders: get().getResolvedCustomHeaders(),
       })
       set((state) => ({
         requestStates: {

--- a/src/test/curl-builder.test.ts
+++ b/src/test/curl-builder.test.ts
@@ -42,6 +42,23 @@ describe('cURL Builder', () => {
     expect(curl).toContain("it'\\''s a test")
   })
 
+  it('includes custom headers before SOAP headers', () => {
+    const curl = buildCurlCommand({
+      endpointUrl: 'http://example.com/service',
+      soapAction: 'urn:test',
+      soapVersion: '1.1',
+      body: '<test/>',
+      customHeaders: { Authorization: 'Bearer token', 'X-Api-Key': 'abc' },
+    })
+
+    expect(curl).toContain("Authorization: Bearer token")
+    expect(curl).toContain("X-Api-Key: abc")
+    // Custom headers should appear before SOAP headers
+    const authIndex = curl.indexOf('Authorization')
+    const contentTypeIndex = curl.indexOf('Content-Type')
+    expect(authIndex).toBeLessThan(contentTypeIndex)
+  })
+
   it('formats with line continuations', () => {
     const curl = buildCurlCommand({
       endpointUrl: 'http://example.com/service',

--- a/src/test/request-sender.test.ts
+++ b/src/test/request-sender.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { sendSoapRequest } from '@/lib/soap/request-sender'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function fakeResponse(body = '<ok/>') {
+  return {
+    status: 200,
+    statusText: 'OK',
+    text: () => Promise.resolve(body),
+    headers: new Headers(),
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  mockFetch.mockResolvedValue(fakeResponse())
+})
+
+describe('sendSoapRequest', () => {
+  it('includes custom headers in the request', async () => {
+    await sendSoapRequest({
+      endpointUrl: 'http://example.com/ws',
+      soapAction: 'urn:test',
+      soapVersion: '1.1',
+      envelopeXml: '<Envelope/>',
+      customHeaders: { Authorization: 'Bearer abc', 'X-Api-Key': '123' },
+    })
+
+    const [, init] = mockFetch.mock.calls[0]
+    expect(init.headers['Authorization']).toBe('Bearer abc')
+    expect(init.headers['X-Api-Key']).toBe('123')
+  })
+
+  it('SOAP headers take precedence over custom headers', async () => {
+    await sendSoapRequest({
+      endpointUrl: 'http://example.com/ws',
+      soapAction: 'urn:test',
+      soapVersion: '1.1',
+      envelopeXml: '<Envelope/>',
+      customHeaders: { 'Content-Type': 'application/json' },
+    })
+
+    const [, init] = mockFetch.mock.calls[0]
+    expect(init.headers['Content-Type']).toBe('text/xml; charset=utf-8')
+  })
+
+  it('works without custom headers', async () => {
+    await sendSoapRequest({
+      endpointUrl: 'http://example.com/ws',
+      soapAction: 'urn:test',
+      soapVersion: '1.2',
+      envelopeXml: '<Envelope/>',
+    })
+
+    const [, init] = mockFetch.mock.calls[0]
+    expect(init.headers['Content-Type']).toContain('application/soap+xml')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a global custom headers panel below the Base URL override in the service header area
- Users can add, toggle, and remove key/value header pairs (e.g. Authorization, API keys, WS-Security tokens)
- Custom headers are included in SOAP requests and "Copy as cURL" output
- SOAP-required headers (Content-Type, SOAPAction) always take precedence over custom headers

## Test plan
- [x] Unit tests for request sender (custom header merging, SOAP header precedence)
- [x] Unit tests for cURL builder (custom headers in output)
- [x] All 60 unit tests pass
- [x] All 11 e2e tests pass
- [x] Manual: load a WSDL, add a custom header, execute a request, verify header in network tab
- [x] Manual: "Copy as cURL" includes custom headers
- [x] Manual: toggle header off, verify it's excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #8