### PR TITLE
feat: SOAP Fault parsing and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Then open http://localhost:8080 in your browser.
 - **Auto-generated SOAP requests** from XSD type definitions, with sample values pre-filled
 - **"Try it out" mode** — edit the generated XML, then execute the request and see the response
 - **Syntax-highlighted XML** for requests and responses
+- **SOAP Fault display** — detects `<soap:Fault>` in responses and renders faultcode, faultstring, and detail in a structured format
 - **Response metadata** — HTTP status, response time, full response body
 - **Copy as cURL** — copy the SOAP request as a ready-to-use cURL command
 - **Inline documentation** — displays `<wsdl:documentation>` from services and operations

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,8 +15,8 @@ Support `?url=...` to pre-load a WSDL and `#service/endpoint/operation` to auto-
 ### 3. Custom request headers (including WS-Security)
 Add a headers panel — global or per-operation — where users can add key/value pairs included in requests. Covers Basic Auth, API keys, and WS-Security tokens.
 
-### 4. SOAP Fault parsing and display
-Detect `<soap:Fault>` in responses and render them distinctly — showing faultcode, faultstring, and detail in a structured, readable format.
+### ~~4. SOAP Fault parsing and display~~ ✅
+~~Detect `<soap:Fault>` in responses and render them distinctly — showing faultcode, faultstring, and detail in a structured, readable format.~~
 
 ### 5. WSDL `<import>` and `<include>` resolution
 Recursive fetching and merging of imported WSDLs and XSD files. Required for many enterprise services that split schemas across multiple files.

--- a/src/components/explorer/OperationDetail.tsx
+++ b/src/components/explorer/OperationDetail.tsx
@@ -3,7 +3,9 @@ import { Play, X, Copy, Check } from 'lucide-react'
 import type { ResolvedOperation } from '@/lib/wsdl/types'
 import { useWsdlStore } from '@/store/wsdl-store'
 import { buildCurlCommand } from '@/lib/soap/curl-builder'
+import { parseSoapFault } from '@/lib/soap/fault-parser'
 import { XmlHighlighter } from '@/components/shared/XmlHighlighter'
+import { SoapFaultAlert } from '@/components/shared/SoapFaultAlert'
 import { LoadingSpinner } from '@/components/shared/LoadingSpinner'
 import { ErrorAlert } from '@/components/shared/ErrorAlert'
 
@@ -153,6 +155,10 @@ export function OperationDetail({ operation, opKey }: OperationDetailProps) {
                     {state.response.durationMs}ms
                   </span>
                 </div>
+                {(() => {
+                  const fault = parseSoapFault(state.response.body)
+                  return fault ? <SoapFaultAlert fault={fault} /> : null
+                })()}
                 <XmlHighlighter xml={state.response.body} />
               </div>
             )}

--- a/src/components/shared/SoapFaultAlert.tsx
+++ b/src/components/shared/SoapFaultAlert.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import { AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react'
+import type { SoapFault } from '@/lib/soap/fault-parser'
+import { XmlHighlighter } from '@/components/shared/XmlHighlighter'
+
+interface SoapFaultAlertProps {
+  fault: SoapFault
+}
+
+export function SoapFaultAlert({ fault }: SoapFaultAlertProps) {
+  const [detailOpen, setDetailOpen] = useState(false)
+
+  return (
+    <div className="rounded-xl border border-[var(--destructive)]/20 bg-[var(--destructive)]/5 px-4 py-3 space-y-2">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="h-4 w-4 text-[var(--destructive)] shrink-0 mt-0.5" />
+        <div className="space-y-1.5 min-w-0">
+          <p className="text-sm font-semibold text-[var(--destructive)]">SOAP Fault</p>
+          <div className="space-y-1 text-xs">
+            <FaultField label="Code" value={fault.code} />
+            <FaultField label="Message" value={fault.string} />
+            {fault.actor && <FaultField label="Actor" value={fault.actor} />}
+            {fault.node && <FaultField label="Node" value={fault.node} />}
+          </div>
+        </div>
+      </div>
+
+      {fault.detail && (
+        <div className="ml-7">
+          <button
+            onClick={() => setDetailOpen(!detailOpen)}
+            className="flex items-center gap-1 text-xs font-medium text-[var(--destructive)]/70 hover:text-[var(--destructive)] transition-colors"
+          >
+            {detailOpen ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+            Detail
+          </button>
+          {detailOpen && (
+            <XmlHighlighter xml={fault.detail} className="mt-1.5 !text-xs" />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function FaultField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <span className="font-medium text-[var(--destructive)]/70 shrink-0">{label}:</span>
+      <span className="text-[var(--foreground)] break-all">{value}</span>
+    </div>
+  )
+}

--- a/src/lib/soap/fault-parser.ts
+++ b/src/lib/soap/fault-parser.ts
@@ -1,0 +1,116 @@
+import { parseXml } from '@/lib/xml/parser'
+import { SOAP_11_ENVELOPE_NS, SOAP_12_ENVELOPE_NS } from '@/lib/soap/constants'
+
+export interface SoapFault {
+  code: string
+  string: string
+  actor?: string
+  node?: string
+  detail?: string
+}
+
+/**
+ * Attempts to detect and parse a SOAP Fault from a response XML string.
+ * Supports both SOAP 1.1 and 1.2 fault structures.
+ * Returns null if the response is not a fault or cannot be parsed.
+ */
+export function parseSoapFault(responseXml: string): SoapFault | null {
+  let doc: Document
+  try {
+    doc = parseXml(responseXml)
+  } catch {
+    return null
+  }
+
+  // Try SOAP 1.1 first, then 1.2
+  const fault = parseSoap11Fault(doc) ?? parseSoap12Fault(doc)
+  return fault
+}
+
+function parseSoap11Fault(doc: Document): SoapFault | null {
+  const fault = doc.getElementsByTagNameNS(SOAP_11_ENVELOPE_NS, 'Fault')[0]
+  if (!fault) return null
+
+  const code = getChildText(fault, 'faultcode')
+  const string = getChildText(fault, 'faultstring')
+  if (!code || !string) return null
+
+  const result: SoapFault = { code, string }
+
+  const actor = getChildText(fault, 'faultactor')
+  if (actor) result.actor = actor
+
+  const detail = getChildElement(fault, 'detail')
+  if (detail) result.detail = serializeChildren(detail)
+
+  return result
+}
+
+function parseSoap12Fault(doc: Document): SoapFault | null {
+  const fault = doc.getElementsByTagNameNS(SOAP_12_ENVELOPE_NS, 'Fault')[0]
+  if (!fault) return null
+
+  const codeEl = getChildElementNS(fault, SOAP_12_ENVELOPE_NS, 'Code')
+  const reasonEl = getChildElementNS(fault, SOAP_12_ENVELOPE_NS, 'Reason')
+  if (!codeEl || !reasonEl) return null
+
+  const code = getChildTextNS(codeEl, SOAP_12_ENVELOPE_NS, 'Value')
+  const string = getChildTextNS(reasonEl, SOAP_12_ENVELOPE_NS, 'Text')
+  if (!code || !string) return null
+
+  const result: SoapFault = { code, string }
+
+  const roleEl = getChildElementNS(fault, SOAP_12_ENVELOPE_NS, 'Role')
+  if (roleEl?.textContent) result.actor = roleEl.textContent.trim()
+
+  const nodeEl = getChildElementNS(fault, SOAP_12_ENVELOPE_NS, 'Node')
+  if (nodeEl?.textContent) result.node = nodeEl.textContent.trim()
+
+  const detailEl = getChildElementNS(fault, SOAP_12_ENVELOPE_NS, 'Detail')
+  if (detailEl) result.detail = serializeChildren(detailEl)
+
+  return result
+}
+
+/** Get text content of a direct child element by local name (no namespace). */
+function getChildText(parent: Element, localName: string): string | null {
+  const el = getChildElement(parent, localName)
+  return el?.textContent?.trim() ?? null
+}
+
+/** Get a direct child element by local name (no namespace). */
+function getChildElement(parent: Element, localName: string): Element | null {
+  for (let i = 0; i < parent.children.length; i++) {
+    if (parent.children[i].localName === localName) {
+      return parent.children[i]
+    }
+  }
+  return null
+}
+
+/** Get a direct child element by namespace and local name. */
+function getChildElementNS(parent: Element, ns: string, localName: string): Element | null {
+  for (let i = 0; i < parent.children.length; i++) {
+    const child = parent.children[i]
+    if (child.localName === localName && child.namespaceURI === ns) {
+      return child
+    }
+  }
+  return null
+}
+
+/** Get text content of a direct child element by namespace and local name. */
+function getChildTextNS(parent: Element, ns: string, localName: string): string | null {
+  const el = getChildElementNS(parent, ns, localName)
+  return el?.textContent?.trim() ?? null
+}
+
+/** Serialize all child nodes of an element to an XML string. */
+function serializeChildren(el: Element): string {
+  const serializer = new XMLSerializer()
+  let result = ''
+  for (let i = 0; i < el.childNodes.length; i++) {
+    result += serializer.serializeToString(el.childNodes[i])
+  }
+  return result.trim()
+}

--- a/src/test/fault-parser.test.ts
+++ b/src/test/fault-parser.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { parseSoapFault } from '@/lib/soap/fault-parser'
+
+describe('SOAP Fault Parser', () => {
+  describe('SOAP 1.1', () => {
+    it('parses a fault with all fields', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>soap:Server</faultcode>
+      <faultstring>Server was unable to process request.</faultstring>
+      <faultactor>http://example.com/actor</faultactor>
+      <detail>
+        <ErrorInfo xmlns="http://example.com/errors">
+          <code>500</code>
+          <message>Internal error</message>
+        </ErrorInfo>
+      </detail>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>`
+
+      const fault = parseSoapFault(xml)
+      expect(fault).not.toBeNull()
+      expect(fault!.code).toBe('soap:Server')
+      expect(fault!.string).toBe('Server was unable to process request.')
+      expect(fault!.actor).toBe('http://example.com/actor')
+      expect(fault!.detail).toContain('ErrorInfo')
+      expect(fault!.detail).toContain('Internal error')
+    })
+
+    it('parses a fault with only required fields', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>soap:Client</faultcode>
+      <faultstring>Invalid input</faultstring>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>`
+
+      const fault = parseSoapFault(xml)
+      expect(fault).not.toBeNull()
+      expect(fault!.code).toBe('soap:Client')
+      expect(fault!.string).toBe('Invalid input')
+      expect(fault!.actor).toBeUndefined()
+      expect(fault!.detail).toBeUndefined()
+    })
+  })
+
+  describe('SOAP 1.2', () => {
+    it('parses a fault with all fields', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+  <soap:Body>
+    <soap:Fault>
+      <soap:Code>
+        <soap:Value>soap:Receiver</soap:Value>
+      </soap:Code>
+      <soap:Reason>
+        <soap:Text xml:lang="en">Processing failed</soap:Text>
+      </soap:Reason>
+      <soap:Role>http://example.com/role</soap:Role>
+      <soap:Node>http://example.com/node</soap:Node>
+      <soap:Detail>
+        <ErrorDetail xmlns="http://example.com/errors">
+          <timestamp>2024-01-01T00:00:00Z</timestamp>
+        </ErrorDetail>
+      </soap:Detail>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>`
+
+      const fault = parseSoapFault(xml)
+      expect(fault).not.toBeNull()
+      expect(fault!.code).toBe('soap:Receiver')
+      expect(fault!.string).toBe('Processing failed')
+      expect(fault!.actor).toBe('http://example.com/role')
+      expect(fault!.node).toBe('http://example.com/node')
+      expect(fault!.detail).toContain('ErrorDetail')
+      expect(fault!.detail).toContain('2024-01-01T00:00:00Z')
+    })
+
+    it('parses a fault with only required fields', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+  <soap:Body>
+    <soap:Fault>
+      <soap:Code>
+        <soap:Value>soap:Sender</soap:Value>
+      </soap:Code>
+      <soap:Reason>
+        <soap:Text xml:lang="en">Bad request</soap:Text>
+      </soap:Reason>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>`
+
+      const fault = parseSoapFault(xml)
+      expect(fault).not.toBeNull()
+      expect(fault!.code).toBe('soap:Sender')
+      expect(fault!.string).toBe('Bad request')
+      expect(fault!.actor).toBeUndefined()
+      expect(fault!.node).toBeUndefined()
+      expect(fault!.detail).toBeUndefined()
+    })
+  })
+
+  describe('non-fault responses', () => {
+    it('returns null for a normal SOAP response', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetPriceResponse xmlns="http://example.com">
+      <price>42.00</price>
+    </GetPriceResponse>
+  </soap:Body>
+</soap:Envelope>`
+
+      expect(parseSoapFault(xml)).toBeNull()
+    })
+
+    it('returns null for malformed XML', () => {
+      expect(parseSoapFault('<not valid xml>>>')).toBeNull()
+    })
+
+    it('returns null for empty string', () => {
+      expect(parseSoapFault('')).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Detect `<soap:Fault>` in SOAP responses and render faultcode, faultstring, actor, and detail in a structured, readable format
- Support both SOAP 1.1 and 1.2 fault structures
- Show a collapsible detail section with syntax-highlighted XML when fault detail is present

## Test plan
- [x] Unit tests for fault parser (SOAP 1.1/1.2, non-fault, malformed XML)
- [x] All existing unit tests pass (63 total)
- [x] All e2e tests pass (11 total)
- [x] TypeScript type check passes
- [ ] Manual: execute a request against a service returning a SOAP fault and verify structured display

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #9