### PR TITLE
feat: resolve WSDL and XSD imports/includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then open http://localhost:8080 in your browser.
 - **Inline documentation** — displays `<wsdl:documentation>` from services and operations
 - **Base URL override** — redirect requests to a different host (e.g. localhost)
 - **Local file support** — browse and load WSDL files from your device
+- **Import/include resolution** — recursive fetching and merging of `<wsdl:import>`, `<xsd:import>`, and `<xsd:include>` across multiple files
 - **Deep linking** — shareable URLs with `?url=` to pre-load a WSDL and `#service/endpoint/operation` to jump to a specific operation
 
 ## Screenshots

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,8 +18,8 @@ Add a headers panel — global or per-operation — where users can add key/valu
 ### 4. SOAP Fault parsing and display
 Detect `<soap:Fault>` in responses and render them distinctly — showing faultcode, faultstring, and detail in a structured, readable format.
 
-### 5. WSDL `<import>` and `<include>` resolution
-Recursive fetching and merging of imported WSDLs and XSD files. Required for many enterprise services that split schemas across multiple files.
+### ~~5. WSDL `<import>` and `<include>` resolution~~ ✅
+~~Recursive fetching and merging of imported WSDLs and XSD files. Required for many enterprise services that split schemas across multiple files.~~
 
 ---
 

--- a/src/lib/wsdl/import-resolver.ts
+++ b/src/lib/wsdl/import-resolver.ts
@@ -1,0 +1,261 @@
+import type { WsdlDocument, XsdTypeMap } from './types'
+import { WSDL_11_NS, WSDL_20_NS, XSD_NS } from '../soap/constants'
+import { getChildElements, getFirstChildElement, getAttr } from './xml-helpers'
+import { parseXml } from '../xml/parser'
+import { parseWsdl1 } from './wsdl1-parser'
+import { parseWsdl2 } from './wsdl2-parser'
+import { parseSchemaElements } from './xsd-utils'
+
+function parseWsdlDoc(doc: Document): WsdlDocument {
+  const ns = doc.documentElement.namespaceURI
+  if (ns === WSDL_11_NS) return parseWsdl1(doc)
+  if (ns === WSDL_20_NS) return parseWsdl2(doc)
+  throw new Error(`Unrecognized WSDL namespace: "${ns}"`)
+}
+
+const MAX_DEPTH = 10
+
+interface ResolveContext {
+  visited: Set<string>
+  fetchFn: (url: string) => Promise<Response>
+  depth: number
+}
+
+/**
+ * Resolve all <wsdl:import>, <wsdl:include>, <xsd:import>, and <xsd:include>
+ * elements by fetching referenced documents and merging their contents.
+ */
+export async function resolveImports(
+  doc: WsdlDocument,
+  xmlDoc: Document,
+  baseUrl: string,
+  fetchFn: (url: string) => Promise<Response> = fetch,
+): Promise<WsdlDocument> {
+  const ctx: ResolveContext = {
+    visited: new Set([normalizeUrl(baseUrl)]),
+    fetchFn,
+    depth: 0,
+  }
+  return resolveImportsWithContext(doc, xmlDoc, baseUrl, ctx)
+}
+
+async function resolveImportsWithContext(
+  doc: WsdlDocument,
+  xmlDoc: Document,
+  baseUrl: string,
+  ctx: ResolveContext,
+): Promise<WsdlDocument> {
+  const root = xmlDoc.documentElement
+  const wsdlNs = doc.version === '1.1' ? WSDL_11_NS : WSDL_20_NS
+
+  // Resolve WSDL imports/includes
+  const importedWsdls = await resolveWsdlImports(root, wsdlNs, doc.version, baseUrl, ctx)
+
+  // Resolve XSD imports/includes within <types>
+  const typesEl = getFirstChildElement(root, wsdlNs, 'types')
+  const importedTypes = await resolveXsdImports(typesEl, baseUrl, ctx)
+
+  // Merge everything
+  let merged = mergeWsdlDocuments(doc, importedWsdls)
+  merged = { ...merged, types: { ...importedTypes, ...merged.types } }
+  return merged
+}
+
+async function resolveWsdlImports(
+  rootEl: Element,
+  wsdlNs: string,
+  version: string,
+  baseUrl: string,
+  ctx: ResolveContext,
+): Promise<WsdlDocument[]> {
+  if (ctx.depth >= MAX_DEPTH) return []
+
+  const results: WsdlDocument[] = []
+
+  // <wsdl:import> (both 1.1 and 2.0)
+  const imports = getChildElements(rootEl, wsdlNs, 'import')
+  // <wsdl:include> (2.0 only)
+  const includes = version === '2.0' ? getChildElements(rootEl, wsdlNs, 'include') : []
+
+  for (const el of [...imports, ...includes]) {
+    const location = getAttr(el, 'location')
+    if (!location) continue
+
+    const absoluteUrl = resolveUrl(location, baseUrl)
+    if (!absoluteUrl) continue
+
+    const normalized = normalizeUrl(absoluteUrl)
+    if (ctx.visited.has(normalized)) continue
+    ctx.visited.add(normalized)
+
+    try {
+      const response = await ctx.fetchFn(absoluteUrl)
+      if (!response.ok) continue
+      const text = await response.text()
+      const xmlDoc = parseXml(text)
+      const doc = parseWsdlDoc(xmlDoc)
+      const childCtx = { ...ctx, depth: ctx.depth + 1 }
+      const resolved = await resolveImportsWithContext(doc, xmlDoc, absoluteUrl, childCtx)
+      results.push(resolved)
+    } catch {
+      // Gracefully skip failed imports
+    }
+  }
+
+  return results
+}
+
+async function resolveXsdImports(
+  typesEl: Element | null,
+  baseUrl: string,
+  ctx: ResolveContext,
+): Promise<XsdTypeMap> {
+  if (!typesEl || ctx.depth >= MAX_DEPTH) return {}
+
+  const typeMap: XsdTypeMap = {}
+  const schemas = getChildElements(typesEl, XSD_NS, 'schema')
+
+  for (const schema of schemas) {
+    const imports = getChildElements(schema, XSD_NS, 'import')
+    const includes = getChildElements(schema, XSD_NS, 'include')
+
+    for (const el of [...imports, ...includes]) {
+      const location = getAttr(el, 'schemaLocation')
+      if (!location) continue
+
+      const absoluteUrl = resolveUrl(location, baseUrl)
+      if (!absoluteUrl) continue
+
+      const normalized = normalizeUrl(absoluteUrl)
+      if (ctx.visited.has(normalized)) continue
+      ctx.visited.add(normalized)
+
+      try {
+        const response = await ctx.fetchFn(absoluteUrl)
+        if (!response.ok) continue
+        const text = await response.text()
+        const xsdDoc = parseXml(text)
+        const xsdRoot = xsdDoc.documentElement
+
+        if (xsdRoot.localName === 'schema' && xsdRoot.namespaceURI === XSD_NS) {
+          const tns = getAttr(xsdRoot, 'targetNamespace') ?? ''
+          parseSchemaElements(xsdRoot, tns, typeMap)
+
+          // Recursively resolve nested XSD imports
+          const nestedTypes = await resolveXsdImportsFromSchema(xsdRoot, absoluteUrl, ctx)
+          Object.assign(typeMap, nestedTypes)
+        }
+      } catch {
+        // Gracefully skip failed imports
+      }
+    }
+  }
+
+  return typeMap
+}
+
+async function resolveXsdImportsFromSchema(
+  schema: Element,
+  baseUrl: string,
+  ctx: ResolveContext,
+): Promise<XsdTypeMap> {
+  if (ctx.depth >= MAX_DEPTH) return {}
+
+  const typeMap: XsdTypeMap = {}
+  const imports = getChildElements(schema, XSD_NS, 'import')
+  const includes = getChildElements(schema, XSD_NS, 'include')
+
+  for (const el of [...imports, ...includes]) {
+    const location = getAttr(el, 'schemaLocation')
+    if (!location) continue
+
+    const absoluteUrl = resolveUrl(location, baseUrl)
+    if (!absoluteUrl) continue
+
+    const normalized = normalizeUrl(absoluteUrl)
+    if (ctx.visited.has(normalized)) continue
+    ctx.visited.add(normalized)
+
+    try {
+      const response = await ctx.fetchFn(absoluteUrl)
+      if (!response.ok) continue
+      const text = await response.text()
+      const xsdDoc = parseXml(text)
+      const xsdRoot = xsdDoc.documentElement
+
+      if (xsdRoot.localName === 'schema' && xsdRoot.namespaceURI === XSD_NS) {
+        const tns = getAttr(xsdRoot, 'targetNamespace') ?? ''
+        parseSchemaElements(xsdRoot, tns, typeMap)
+        const nested = await resolveXsdImportsFromSchema(xsdRoot, absoluteUrl, ctx)
+        Object.assign(typeMap, nested)
+      }
+    } catch {
+      // Gracefully skip
+    }
+  }
+
+  return typeMap
+}
+
+function mergeWsdlDocuments(root: WsdlDocument, imported: WsdlDocument[]): WsdlDocument {
+  if (imported.length === 0) return root
+
+  const serviceNames = new Set(root.services.map((s) => s.name))
+  const bindingNames = new Set(root.bindings.map((b) => b.name))
+  const interfaceNames = new Set(root.interfaces.map((i) => i.name))
+  let mergedTypes: XsdTypeMap = { ...root.types }
+
+  const mergedServices = [...root.services]
+  const mergedBindings = [...root.bindings]
+  const mergedInterfaces = [...root.interfaces]
+
+  for (const doc of imported) {
+    for (const s of doc.services) {
+      if (!serviceNames.has(s.name)) {
+        mergedServices.push(s)
+        serviceNames.add(s.name)
+      }
+    }
+    for (const b of doc.bindings) {
+      if (!bindingNames.has(b.name)) {
+        mergedBindings.push(b)
+        bindingNames.add(b.name)
+      }
+    }
+    for (const i of doc.interfaces) {
+      if (!interfaceNames.has(i.name)) {
+        mergedInterfaces.push(i)
+        interfaceNames.add(i.name)
+      }
+    }
+    // Imported types: root wins on conflicts
+    mergedTypes = { ...doc.types, ...mergedTypes }
+  }
+
+  return {
+    ...root,
+    services: mergedServices,
+    bindings: mergedBindings,
+    interfaces: mergedInterfaces,
+    types: mergedTypes,
+  }
+}
+
+function resolveUrl(location: string, baseUrl: string): string | null {
+  try {
+    return new URL(location, baseUrl).href
+  } catch {
+    return null
+  }
+}
+
+function normalizeUrl(url: string): string {
+  try {
+    const u = new URL(url)
+    // Strip fragment
+    u.hash = ''
+    return u.href
+  } catch {
+    return url
+  }
+}

--- a/src/lib/wsdl/parser.ts
+++ b/src/lib/wsdl/parser.ts
@@ -3,6 +3,7 @@ import { WSDL_11_NS, WSDL_20_NS } from '../soap/constants'
 import { parseXml } from '../xml/parser'
 import { parseWsdl1 } from './wsdl1-parser'
 import { parseWsdl2 } from './wsdl2-parser'
+import { resolveImports } from './import-resolver'
 
 export class WsdlParseError extends Error {
   constructor(message: string) {
@@ -20,7 +21,9 @@ export async function fetchAndParseWsdl(url: string): Promise<WsdlDocument> {
     throw new WsdlParseError(`Failed to fetch WSDL: ${response.status} ${response.statusText}`)
   }
   const text = await response.text()
-  return parseWsdlText(text)
+  const xmlDoc = parseXml(text)
+  const doc = parseWsdlDocument(xmlDoc)
+  return resolveImports(doc, xmlDoc, url)
 }
 
 /**

--- a/src/lib/wsdl/xsd-utils.ts
+++ b/src/lib/wsdl/xsd-utils.ts
@@ -17,7 +17,7 @@ export function parseXsdTypes(typesElement: Element | null): XsdTypeMap {
   return typeMap
 }
 
-function parseSchemaElements(schema: Element, tns: string, typeMap: XsdTypeMap): void {
+export function parseSchemaElements(schema: Element, tns: string, typeMap: XsdTypeMap): void {
   // Parse top-level elements
   for (const el of getChildElements(schema, XSD_NS, 'element')) {
     const name = getAttr(el, 'name')

--- a/src/test/fixtures/common-types.xsd
+++ b/src/test/fixtures/common-types.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://example.com/common-types">
+
+  <xsd:complexType name="Address">
+    <xsd:sequence>
+      <xsd:element name="street" type="xsd:string"/>
+      <xsd:element name="city" type="xsd:string"/>
+      <xsd:element name="zip" type="xsd:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="Currency">
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/src/test/fixtures/wsdl11-circular-a.xml
+++ b/src/test/fixtures/wsdl11-circular-a.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/circular-a"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             name="CircularA"
+             targetNamespace="http://example.com/circular-a">
+
+  <import namespace="http://example.com/circular-b" location="http://example.com/circular-b.wsdl"/>
+
+  <types>
+    <xsd:schema targetNamespace="http://example.com/circular-a">
+      <xsd:element name="OpA">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="value" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </types>
+
+  <message name="OpAInput">
+    <part name="body" element="tns:OpA"/>
+  </message>
+
+  <portType name="CircularAPortType">
+    <operation name="OpA">
+      <input message="tns:OpAInput"/>
+    </operation>
+  </portType>
+
+  <binding name="CircularASoapBinding" type="tns:CircularAPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="OpA">
+      <soap:operation soapAction="http://example.com/OpA"/>
+      <input><soap:body use="literal"/></input>
+    </operation>
+  </binding>
+
+  <service name="CircularAService">
+    <port name="CircularAPort" binding="tns:CircularASoapBinding">
+      <soap:address location="http://example.com/circular-a"/>
+    </port>
+  </service>
+</definitions>

--- a/src/test/fixtures/wsdl11-circular-b.xml
+++ b/src/test/fixtures/wsdl11-circular-b.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/circular-b"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             name="CircularB"
+             targetNamespace="http://example.com/circular-b">
+
+  <import namespace="http://example.com/circular-a" location="http://example.com/circular-a.wsdl"/>
+
+  <types>
+    <xsd:schema targetNamespace="http://example.com/circular-b">
+      <xsd:element name="OpB">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="data" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </types>
+
+  <message name="OpBInput">
+    <part name="body" element="tns:OpB"/>
+  </message>
+
+  <portType name="CircularBPortType">
+    <operation name="OpB">
+      <input message="tns:OpBInput"/>
+    </operation>
+  </portType>
+
+  <binding name="CircularBSoapBinding" type="tns:CircularBPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="OpB">
+      <soap:operation soapAction="http://example.com/OpB"/>
+      <input><soap:body use="literal"/></input>
+    </operation>
+  </binding>
+
+  <service name="CircularBService">
+    <port name="CircularBPort" binding="tns:CircularBSoapBinding">
+      <soap:address location="http://example.com/circular-b"/>
+    </port>
+  </service>
+</definitions>

--- a/src/test/fixtures/wsdl11-imported.xml
+++ b/src/test/fixtures/wsdl11-imported.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/imported"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             name="ImportedService"
+             targetNamespace="http://example.com/imported">
+
+  <types>
+    <xsd:schema targetNamespace="http://example.com/imported">
+      <xsd:element name="Echo">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="text" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="EchoResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="result" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </types>
+
+  <message name="EchoInput">
+    <part name="body" element="tns:Echo"/>
+  </message>
+  <message name="EchoOutput">
+    <part name="body" element="tns:EchoResponse"/>
+  </message>
+
+  <portType name="ImportedPortType">
+    <operation name="Echo">
+      <input message="tns:EchoInput"/>
+      <output message="tns:EchoOutput"/>
+    </operation>
+  </portType>
+
+  <binding name="ImportedSoapBinding" type="tns:ImportedPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="Echo">
+      <soap:operation soapAction="http://example.com/Echo"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+
+  <service name="ImportedService">
+    <port name="ImportedPort" binding="tns:ImportedSoapBinding">
+      <soap:address location="http://example.com/imported"/>
+    </port>
+  </service>
+</definitions>

--- a/src/test/fixtures/wsdl11-with-import.xml
+++ b/src/test/fixtures/wsdl11-with-import.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/main"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             name="MainService"
+             targetNamespace="http://example.com/main">
+
+  <import namespace="http://example.com/imported" location="http://example.com/imported.wsdl"/>
+
+  <types>
+    <xsd:schema targetNamespace="http://example.com/main">
+      <xsd:element name="Ping">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="message" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="PingResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="reply" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </types>
+
+  <message name="PingInput">
+    <part name="body" element="tns:Ping"/>
+  </message>
+  <message name="PingOutput">
+    <part name="body" element="tns:PingResponse"/>
+  </message>
+
+  <portType name="MainPortType">
+    <operation name="Ping">
+      <input message="tns:PingInput"/>
+      <output message="tns:PingOutput"/>
+    </operation>
+  </portType>
+
+  <binding name="MainSoapBinding" type="tns:MainPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="Ping">
+      <soap:operation soapAction="http://example.com/Ping"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+
+  <service name="MainService">
+    <port name="MainPort" binding="tns:MainSoapBinding">
+      <soap:address location="http://example.com/main"/>
+    </port>
+  </service>
+</definitions>

--- a/src/test/fixtures/wsdl11-with-xsd-import.xml
+++ b/src/test/fixtures/wsdl11-with-xsd-import.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/order"
+             xmlns:ct="http://example.com/common-types"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             name="OrderService"
+             targetNamespace="http://example.com/order">
+
+  <types>
+    <xsd:schema targetNamespace="http://example.com/order">
+      <xsd:import namespace="http://example.com/common-types" schemaLocation="http://example.com/common-types.xsd"/>
+      <xsd:element name="PlaceOrder">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="item" type="xsd:string"/>
+            <xsd:element name="quantity" type="xsd:int"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="PlaceOrderResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="orderId" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </types>
+
+  <message name="PlaceOrderInput">
+    <part name="body" element="tns:PlaceOrder"/>
+  </message>
+  <message name="PlaceOrderOutput">
+    <part name="body" element="tns:PlaceOrderResponse"/>
+  </message>
+
+  <portType name="OrderPortType">
+    <operation name="PlaceOrder">
+      <input message="tns:PlaceOrderInput"/>
+      <output message="tns:PlaceOrderOutput"/>
+    </operation>
+  </portType>
+
+  <binding name="OrderSoapBinding" type="tns:OrderPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="PlaceOrder">
+      <soap:operation soapAction="http://example.com/PlaceOrder"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+
+  <service name="OrderService">
+    <port name="OrderPort" binding="tns:OrderSoapBinding">
+      <soap:address location="http://example.com/order"/>
+    </port>
+  </service>
+</definitions>

--- a/src/test/import-resolver.test.ts
+++ b/src/test/import-resolver.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { parseWsdlText, resolveOperations } from '@/lib/wsdl/parser'
+import { resolveImports } from '@/lib/wsdl/import-resolver'
+import { parseXml } from '@/lib/xml/parser'
+
+function loadFixture(name: string): string {
+  return readFileSync(join(__dirname, 'fixtures', name), 'utf-8')
+}
+
+function mockFetchFn(fixtures: Record<string, string>) {
+  return async (url: string) => {
+    const text = fixtures[url]
+    if (text === undefined) {
+      return { ok: false, status: 404, statusText: 'Not Found', text: async () => '' } as Response
+    }
+    return { ok: true, status: 200, statusText: 'OK', text: async () => text } as Response
+  }
+}
+
+describe('Import Resolver', () => {
+  describe('WSDL import', () => {
+    const mainText = loadFixture('wsdl11-with-import.xml')
+    const importedText = loadFixture('wsdl11-imported.xml')
+    const fetchFn = mockFetchFn({
+      'http://example.com/imported.wsdl': importedText,
+    })
+
+    it('merges services from imported WSDL', async () => {
+      const xmlDoc = parseXml(mainText)
+      const doc = parseWsdlText(mainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/main.wsdl', fetchFn)
+
+      const serviceNames = resolved.services.map((s) => s.name)
+      expect(serviceNames).toContain('MainService')
+      expect(serviceNames).toContain('ImportedService')
+    })
+
+    it('merges bindings from imported WSDL', async () => {
+      const xmlDoc = parseXml(mainText)
+      const doc = parseWsdlText(mainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/main.wsdl', fetchFn)
+
+      const bindingNames = resolved.bindings.map((b) => b.name)
+      expect(bindingNames).toContain('MainSoapBinding')
+      expect(bindingNames).toContain('ImportedSoapBinding')
+    })
+
+    it('merges interfaces from imported WSDL', async () => {
+      const xmlDoc = parseXml(mainText)
+      const doc = parseWsdlText(mainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/main.wsdl', fetchFn)
+
+      const interfaceNames = resolved.interfaces.map((i) => i.name)
+      expect(interfaceNames).toContain('MainPortType')
+      expect(interfaceNames).toContain('ImportedPortType')
+    })
+
+    it('merges types from imported WSDL', async () => {
+      const xmlDoc = parseXml(mainText)
+      const doc = parseWsdlText(mainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/main.wsdl', fetchFn)
+
+      expect(resolved.types['Echo']).toBeDefined()
+      expect(resolved.types['Ping']).toBeDefined()
+    })
+
+    it('resolves operations from both main and imported WSDL', async () => {
+      const xmlDoc = parseXml(mainText)
+      const doc = parseWsdlText(mainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/main.wsdl', fetchFn)
+      const ops = resolveOperations(resolved)
+
+      const opNames = ops.map((o) => o.operationName)
+      expect(opNames).toContain('Ping')
+      expect(opNames).toContain('Echo')
+    })
+  })
+
+  describe('XSD import', () => {
+    const mainText = loadFixture('wsdl11-with-xsd-import.xml')
+    const xsdText = loadFixture('common-types.xsd')
+    const fetchFn = mockFetchFn({
+      'http://example.com/common-types.xsd': xsdText,
+    })
+
+    it('merges types from imported XSD', async () => {
+      const xmlDoc = parseXml(mainText)
+      const doc = parseWsdlText(mainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/order.wsdl', fetchFn)
+
+      expect(resolved.types['Address']).toBeDefined()
+      expect(resolved.types['Address'].kind).toBe('complex')
+      expect(resolved.types['Address'].fields).toHaveLength(3)
+    })
+
+    it('merges simple types from imported XSD', async () => {
+      const xmlDoc = parseXml(mainText)
+      const doc = parseWsdlText(mainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/order.wsdl', fetchFn)
+
+      expect(resolved.types['Currency']).toBeDefined()
+      expect(resolved.types['Currency'].kind).toBe('simple')
+    })
+
+    it('preserves inline types alongside imported types', async () => {
+      const xmlDoc = parseXml(mainText)
+      const doc = parseWsdlText(mainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/order.wsdl', fetchFn)
+
+      expect(resolved.types['PlaceOrder']).toBeDefined()
+      expect(resolved.types['Address']).toBeDefined()
+    })
+  })
+
+  describe('circular imports', () => {
+    const circularAText = loadFixture('wsdl11-circular-a.xml')
+    const circularBText = loadFixture('wsdl11-circular-b.xml')
+    const fetchFn = mockFetchFn({
+      'http://example.com/circular-a.wsdl': circularAText,
+      'http://example.com/circular-b.wsdl': circularBText,
+    })
+
+    it('terminates without error', async () => {
+      const xmlDoc = parseXml(circularAText)
+      const doc = parseWsdlText(circularAText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/circular-a.wsdl', fetchFn)
+
+      expect(resolved.services).toHaveLength(2)
+      const serviceNames = resolved.services.map((s) => s.name)
+      expect(serviceNames).toContain('CircularAService')
+      expect(serviceNames).toContain('CircularBService')
+    })
+  })
+
+  describe('failed imports', () => {
+    const mainText = loadFixture('wsdl11-with-import.xml')
+    const fetchFn = mockFetchFn({}) // no fixtures — all fetches will 404
+
+    it('gracefully skips failed imports', async () => {
+      const xmlDoc = parseXml(mainText)
+      const doc = parseWsdlText(mainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/main.wsdl', fetchFn)
+
+      // Should still have the main service
+      expect(resolved.services).toHaveLength(1)
+      expect(resolved.services[0].name).toBe('MainService')
+    })
+  })
+
+  describe('relative URL resolution', () => {
+    const mainText = loadFixture('wsdl11-with-xsd-import.xml')
+    const xsdText = loadFixture('common-types.xsd')
+
+    it('resolves relative schemaLocation against base URL', async () => {
+      // Modify the fixture to use a relative URL by adjusting what the mock returns
+      const relativeMainText = mainText.replace(
+        'schemaLocation="http://example.com/common-types.xsd"',
+        'schemaLocation="common-types.xsd"',
+      )
+      const fetchFn = mockFetchFn({
+        'http://example.com/schemas/common-types.xsd': xsdText,
+      })
+
+      const xmlDoc = parseXml(relativeMainText)
+      const doc = parseWsdlText(relativeMainText)
+      const resolved = await resolveImports(doc, xmlDoc, 'http://example.com/schemas/order.wsdl', fetchFn)
+
+      expect(resolved.types['Address']).toBeDefined()
+    })
+  })
+
+  describe('parseWsdlText without imports', () => {
+    it('still works for self-contained WSDLs', () => {
+      const text = loadFixture('wsdl11-document.xml')
+      const doc = parseWsdlText(text)
+
+      expect(doc.services).toHaveLength(1)
+      expect(doc.types['GetLastTradePrice']).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds recursive fetching and merging of `<wsdl:import>`, `<wsdl:include>`, `<xsd:import>`, and `<xsd:include>` elements (roadmap item 5)
- Imported services, bindings, interfaces, and types are merged into the root WSDL document with cycle detection and graceful error handling
- No changes to the synchronous `parseWsdlText` path — import resolution only runs for URL-loaded WSDLs via `fetchAndParseWsdl`

## Test plan

- [x] 12 new unit tests covering WSDL import, XSD import, circular imports, failed fetches, relative URL resolution
- [x] All 68 unit tests pass (no regressions)
- [x] All 11 e2e tests pass
- [ ] Manual: load an enterprise WSDL with imports via URL and verify imported types appear in generated SOAP envelopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #10