### PR TITLE
fix: build multiplatform Docker image for arm64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add `linux/amd64,linux/arm64` platforms to the Docker build so the image works on Apple Silicon (and other arm64 hosts)

## Test plan
- [x] CI docker job passes with the new platforms config
- [ ] After next tagged release, verify `docker run -p 8080:80 outofcoffee/wsdl-web` works on an arm64 machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)