### PR TITLE
fix: extract SOAPAction from WSDL 2.0 interface operations

### DIFF
--- a/src/lib/wsdl/parser.ts
+++ b/src/lib/wsdl/parser.ts
@@ -76,7 +76,7 @@ export function resolveOperations(wsdl: WsdlDocument): ResolvedOperation[] {
           soapVersion: binding.soapVersion,
           operationName: bindingOp.name,
           documentation: ifaceOp?.documentation,
-          soapAction: bindingOp.soapAction,
+          soapAction: bindingOp.soapAction || ifaceOp?.soapAction || '',
           input: ifaceOp?.input ?? null,
           output: ifaceOp?.output ?? null,
           targetNamespace: wsdl.targetNamespace,

--- a/src/lib/wsdl/types.ts
+++ b/src/lib/wsdl/types.ts
@@ -51,6 +51,7 @@ export interface WsdlInterface {
 export interface WsdlInterfaceOperation {
   name: string
   documentation?: string
+  soapAction?: string
   input: WsdlMessage | null
   output: WsdlMessage | null
 }

--- a/src/lib/wsdl/wsdl2-parser.ts
+++ b/src/lib/wsdl/wsdl2-parser.ts
@@ -12,7 +12,7 @@ import type {
   SoapVersion,
 } from './types'
 import { WSDL_20_NS } from '../soap/constants'
-import { getChildElements, getFirstChildElement, getAttr, getLocalPart, getDocumentation } from './xml-helpers'
+import { getChildElements, getFirstChildElement, getAttr, getAttrNS, getLocalPart, getDocumentation } from './xml-helpers'
 import { parseXsdTypes } from './xsd-utils'
 
 // WSDL 2.0 uses a different SOAP binding namespace
@@ -77,8 +77,12 @@ function parseInterfaces(root: Element): WsdlInterface[] {
         ? { name: `${opName}Output`, parts: [{ name: 'parameters', element: getLocalPart(outputElementRef) }] }
         : null
 
+      // Extract soapAction from <wsoap:operation soapAction="..."/> child element
+      const wsoapOpEl = getFirstChildElement(opEl, WSDL2_SOAP_NS, 'operation')
+      const soapAction = wsoapOpEl ? getAttr(wsoapOpEl, 'soapAction') : undefined
+
       const opDoc = getDocumentation(opEl, WSDL_20_NS)
-      operations.push({ name: opName, documentation: opDoc, input, output })
+      operations.push({ name: opName, documentation: opDoc, soapAction, input, output })
     }
 
     const ifDoc = getDocumentation(ifEl, WSDL_20_NS)
@@ -116,7 +120,7 @@ function parseBindings(root: Element): WsdlBinding[] {
       const opName = getAttr(opEl, 'ref')
       if (!opName) continue
 
-      const soapAction = getAttr(opEl, `${WSDL2_SOAP_NS}:action`) ?? ''
+      const soapAction = getAttrNS(opEl, WSDL2_SOAP_NS, 'action') ?? ''
 
       operations.push({
         name: getLocalPart(opName),

--- a/src/lib/wsdl/xml-helpers.ts
+++ b/src/lib/wsdl/xml-helpers.ts
@@ -72,3 +72,10 @@ export function getDocumentation(
 export function getAttr(el: Element, name: string): string | undefined {
   return el.hasAttribute(name) ? el.getAttribute(name)! : undefined
 }
+
+/**
+ * Get a namespace-qualified attribute value or undefined.
+ */
+export function getAttrNS(el: Element, namespace: string, localName: string): string | undefined {
+  return el.hasAttributeNS(namespace, localName) ? el.getAttributeNS(namespace, localName)! : undefined
+}

--- a/src/test/fixtures/wsdl20-interface-soapaction.xml
+++ b/src/test/fixtures/wsdl20-interface-soapaction.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description xmlns="http://www.w3.org/ns/wsdl"
+             xmlns:tns="urn:com:example:petstore"
+             xmlns:wsoap="http://www.w3.org/ns/wsdl/soap"
+             targetNamespace="urn:com:example:petstore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.w3.org/ns/wsdl/soap http://www.w3.org/2002/ws/desc/ns/soap.xsd">
+
+    <types>
+        <xs:schema elementFormDefault="unqualified" targetNamespace="urn:com:example:petstore" version="1.0"
+                   xmlns:tns="urn:com:example:petstore"
+                   xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+            <xs:complexType name="getPetByIdRequest">
+                <xs:all>
+                    <xs:element name="id" type="xs:int"/>
+                </xs:all>
+            </xs:complexType>
+
+            <xs:complexType name="petType">
+                <xs:all>
+                    <xs:element name="id" type="xs:int"/>
+                    <xs:element name="name" type="xs:string"/>
+                </xs:all>
+            </xs:complexType>
+
+            <xs:element name="getPetByIdRequest" type="tns:getPetByIdRequest"/>
+            <xs:element name="getPetByIdResponse" type="tns:petType"/>
+        </xs:schema>
+    </types>
+
+    <interface name="PetInterface">
+        <operation name="getPetById" pattern="http://www.w3.org/ns/wsdl/in-out">
+            <wsoap:operation soapAction="getPetById" style="document"/>
+            <input messageLabel="In" element="tns:getPetByIdRequest"/>
+            <output messageLabel="Out" element="tns:getPetByIdResponse"/>
+        </operation>
+    </interface>
+
+    <binding name="SoapBinding" interface="tns:PetInterface"
+             type="http://www.w3.org/ns/wsdl/soap"
+             wsoap:protocol="http://www.w3.org/2003/05/soap/bindings/HTTP/"
+             wsoap:mepDefault="http://www.w3.org/2003/05/soap/mep/request-response">
+        <operation ref="tns:getPetById"/>
+    </binding>
+
+    <service name="PetService" interface="tns:PetInterface">
+        <endpoint name="SoapEndpoint"
+                  binding="tns:SoapBinding"
+                  address="http://www.example.com/pets/"/>
+    </service>
+</description>

--- a/src/test/wsdl2-parser.test.ts
+++ b/src/test/wsdl2-parser.test.ts
@@ -80,4 +80,24 @@ describe('WSDL 2.0 Parser', () => {
     expect(ops[0].soapVersion).toBe('1.2')
     expect(ops[0].endpointAddress).toBe('http://example.com/weather')
   })
+
+  it('resolves soapAction from binding wsoap:action attribute', () => {
+    const ops = resolveOperations(wsdl)
+    expect(ops[0].soapAction).toBe('http://example.com/GetWeather')
+  })
+})
+
+describe('WSDL 2.0 Parser – soapAction on interface operation', () => {
+  const wsdl = parseWsdlText(loadFixture('wsdl20-interface-soapaction.xml'))
+
+  it('extracts soapAction from wsoap:operation child element', () => {
+    const op = wsdl.interfaces[0].operations[0]
+    expect(op.soapAction).toBe('getPetById')
+  })
+
+  it('resolves soapAction via interface fallback when binding has none', () => {
+    const ops = resolveOperations(wsdl)
+    expect(ops).toHaveLength(1)
+    expect(ops[0].soapAction).toBe('getPetById')
+  })
 })


### PR DESCRIPTION
## Summary
- WSDL 2.0 documents can define `soapAction` on a `<wsoap:operation>` child element inside interface operations (not just on binding operations). The parser was not extracting it from this location, resulting in an empty SOAPAction in generated requests.
- Also fixed the binding-level `wsoap:action` attribute lookup to use namespace-aware `getAttributeNS` instead of `getAttribute` with the full namespace URI (which never matched).

## Test plan
- [x] Added test for soapAction extraction from `<wsoap:operation>` in interface operations
- [x] Added test for soapAction resolution fallback (binding → interface)
- [x] Added test for binding-level `wsoap:action` attribute parsing
- [x] All 63 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)