### PR TITLE
feat: add sticky footer with product name and GitHub link

### DIFF
--- a/e2e/wsdl-explorer.spec.ts
+++ b/e2e/wsdl-explorer.spec.ts
@@ -152,6 +152,29 @@ test.describe('WSDL Explorer', () => {
   })
 })
 
+test.describe('Footer', () => {
+  test('displays product name and GitHub link', async ({ page }) => {
+    await page.goto('/')
+    const footer = page.locator('footer')
+    await expect(footer).toBeVisible()
+    await expect(footer.getByText('WSDL Web')).toBeVisible()
+
+    const ghLink = footer.getByRole('link', { name: /GitHub/ })
+    await expect(ghLink).toHaveAttribute('href', 'https://github.com/wsdl-web/wsdl-web')
+    await expect(ghLink).toHaveAttribute('target', '_blank')
+  })
+
+  test('sticks to bottom on short viewport', async ({ page }) => {
+    await page.goto('/')
+    const footer = page.locator('footer')
+    const viewportHeight = page.viewportSize()!.height
+    const footerBox = await footer.boundingBox()
+    expect(footerBox).toBeTruthy()
+    // Footer bottom edge should be at or near the viewport bottom
+    expect(footerBox!.y + footerBox!.height).toBeGreaterThanOrEqual(viewportHeight - 1)
+  })
+})
+
 test.describe('Deep linking', () => {
   test('loads WSDL and expands operation from URL params', async ({ page }) => {
     await mockWsdlFetch(page)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useWsdlStore } from '@/store/wsdl-store'
 import { useDeepLink } from '@/hooks/use-deep-link'
 import { TopBar } from '@/components/layout/TopBar'
+import { Footer } from '@/components/layout/Footer'
 import { ServiceHeader } from '@/components/layout/ServiceHeader'
 import { ServiceList } from '@/components/explorer/ServiceList'
 import { ErrorAlert } from '@/components/shared/ErrorAlert'
@@ -11,7 +12,7 @@ export default function App() {
   const { document, operations, isLoading, error } = useWsdlStore()
 
   return (
-    <div className="min-h-screen bg-[var(--background)]">
+    <div className="flex min-h-screen flex-col bg-[var(--background)]">
       <TopBar />
 
       <main className="mx-auto max-w-4xl px-5 pb-16">
@@ -63,6 +64,8 @@ export default function App() {
           </div>
         )}
       </main>
+
+      <Footer />
     </div>
   )
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,20 @@
+import { Github } from 'lucide-react'
+
+export function Footer() {
+  return (
+    <footer className="mt-auto border-t border-[var(--border)] bg-[var(--background)]">
+      <div className="mx-auto flex max-w-4xl items-center justify-between px-5 py-4 text-xs text-[var(--muted-foreground)]">
+        <span className="font-medium">WSDL Web</span>
+        <a
+          href="https://github.com/wsdl-web/wsdl-web"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 transition-colors hover:text-[var(--foreground)]"
+        >
+          <Github className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">GitHub</span>
+        </a>
+      </div>
+    </footer>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a footer component with the product name ("WSDL Web") and a link to the GitHub repository
- Footer sticks to the bottom of the viewport when page content is short (flexbox `mt-auto` approach)
- Adds two e2e tests: footer content/link verification and sticky-bottom positioning check

## Test plan
- [x] Unit tests pass (60/60)
- [x] E2e tests pass (13/13), including 2 new footer tests
- [x] Visual check: footer visible at bottom on short and long pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)