### PR TITLE
Update documentation URLs to reflect new deployment path

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then open http://localhost:8080 in your browser.
 
 ## Documentation
 
-### [View documentation &rarr;](https://wsdl-web.github.io/wsdl-web)
+### [View documentation &rarr;](https://wsdl-web.github.io)
 
 See an example: [Sample WSDL](https://wsdl-web.github.io/?url=sample.wsdl)
 
@@ -78,7 +78,7 @@ Edit the request XML and execute it directly from the browser.
 Share a URL that pre-loads a WSDL and navigates to a specific operation:
 
 ```
-https://wsdl-web.github.io/wsdl-web/?url=https://example.com/service?wsdl#ServiceName/PortName/OperationName
+https://wsdl-web.github.io/?url=https://example.com/service?wsdl#ServiceName/PortName/OperationName
 ```
 
 - `?url=<wsdl-url>` loads the WSDL automatically

--- a/docs/deep-linking.md
+++ b/docs/deep-linking.md
@@ -5,7 +5,7 @@ Share URLs that pre-load a WSDL and navigate directly to a specific operation.
 ## URL format
 
 ```
-https://wsdl-web.github.io/wsdl-web/?url=<wsdl-url>#<Service>/<Endpoint>/<Operation>
+https://wsdl-web.github.io/?url=<wsdl-url>#<Service>/<Endpoint>/<Operation>
 ```
 
 ## Query parameters
@@ -28,13 +28,13 @@ The hash fragment controls which endpoint group and operation are expanded:
 Load a WSDL and jump to a specific operation:
 
 ```
-https://wsdl-web.github.io/wsdl-web/?url=https://example.com/service?wsdl#StockQuoteService/StockQuotePort/GetLastTradePrice
+https://wsdl-web.github.io/?url=https://example.com/service?wsdl#StockQuoteService/StockQuotePort/GetLastTradePrice
 ```
 
 Load a WSDL without navigating to a specific operation:
 
 ```
-https://wsdl-web.github.io/wsdl-web/?url=https://example.com/service?wsdl
+https://wsdl-web.github.io/?url=https://example.com/service?wsdl
 ```
 
 ## Multiple WSDLs
@@ -42,7 +42,7 @@ https://wsdl-web.github.io/wsdl-web/?url=https://example.com/service?wsdl
 Pass multiple `url` parameters to load several WSDLs with a spec switcher dropdown:
 
 ```
-https://wsdl-web.github.io/wsdl-web/?url=https://example.com/users?wsdl&url=https://example.com/orders?wsdl
+https://wsdl-web.github.io/?url=https://example.com/users?wsdl&url=https://example.com/orders?wsdl
 ```
 
 The first URL is loaded automatically, and a dropdown appears in the top bar to switch between them.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ There are three ways to load a WSDL:
 
 1. **From a URL** — paste a WSDL URL into the search bar and click **Explore** (or press Enter).
 2. **From a local file** — click **Browse** to select a `.wsdl` or `.xml` file from your device.
-3. **From a deep link** — open a URL with `?url=<wsdl-url>` to load a WSDL automatically. Add `#Service/Endpoint/Operation` to jump straight to a specific operation. Example: `https://wsdl-web.github.io/wsdl-web/?url=https://example.com/service?wsdl#MyService/MyPort/GetData`
+3. **From a deep link** — open a URL with `?url=<wsdl-url>` to load a WSDL automatically. Add `#Service/Endpoint/Operation` to jump straight to a specific operation. Example: `https://wsdl-web.github.io/?url=https://example.com/service?wsdl#MyService/MyPort/GetData`
 
 ## Exploring services
 


### PR DESCRIPTION
## Summary
Updated all documentation and README references to reflect the new deployment path for the WSDL Web application. The application is now deployed at the root domain instead of under a `/wsdl-web` subdirectory.

## Changes Made
- Updated all deep-linking examples in `docs/deep-linking.md` to use `https://wsdl-web.github.io/` instead of `https://wsdl-web.github.io/wsdl-web/`
- Updated documentation link in `README.md` to point to the new root path
- Updated example deep-link URL in `README.md` to use the new deployment path
- Updated getting started guide in `docs/getting-started.md` with the corrected deep-link example URL

## Details
All URL references across documentation files have been consistently updated to reflect the simplified deployment structure. This ensures users will access the correct application URL when following documentation examples and deep-linking instructions.
