### PR TITLE
Rename dist bundle to standalone web bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build:standalone
-      - name: Bundle standalone dist
+      - name: Bundle standalone web bundle
         run: |
           cp dist-standalone-template/index.html dist-standalone/
           cd dist-standalone && zip -r ../wsdl-web-standalone.zip .

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The same applies when fetching the WSDL itself — if the WSDL URL doesn't allow
 
 You can embed wsdl-web into your own application or website:
 
-- **[Dist bundle](docs/embedding-dist-bundle.md)** — drop a `<script>` tag into any HTML page, no build step required. Download the standalone zip from [Releases](https://github.com/wsdl-web/wsdl-web/releases) and call `WsdlWeb.init()`.
+- **[Standalone web bundle](docs/embedding-standalone-web-bundle.md)** — drop a `<script>` tag into any HTML page, no build step required. Download the standalone zip from [Releases](https://github.com/wsdl-web/wsdl-web/releases) and call `WsdlWeb.init()`.
 - **[npm package](docs/embedding-npm-package.md)** — use the `<WsdlWeb />` React component in your own project. Install with `npm install wsdl-web`.
 
 Both options support configuration for pre-loading a WSDL URL, hiding UI controls, and overriding the base endpoint URL. See the linked guides for full API details and examples.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ User documentation for WSDL Web.
 
 ## Embedding
 
-- [Embedding with the dist bundle](embedding-dist-bundle.md) — add wsdl-web to any HTML page with a script tag
+- [Embedding with the standalone web bundle](embedding-standalone-web-bundle.md) — add wsdl-web to any HTML page with a script tag
 - [Embedding as an npm package](embedding-npm-package.md) — use the `<WsdlWeb />` React component in your project
 
 ## Deployment

--- a/docs/embedding-standalone-web-bundle.md
+++ b/docs/embedding-standalone-web-bundle.md
@@ -1,6 +1,6 @@
-# Embedding wsdl-web with the Prebuilt Dist Bundle
+# Embedding wsdl-web with the Standalone Web Bundle
 
-The dist bundle lets you embed wsdl-web into any HTML page without a build step or Node.js toolchain. Include a script tag, a stylesheet, and call `WsdlWeb.init()`.
+The standalone web bundle lets you embed wsdl-web into any HTML page without a build step or Node.js toolchain. Include a script tag, a stylesheet, and call `WsdlWeb.init()`.
 
 ## Quick Start
 

--- a/examples/standalone-web-bundle/README.md
+++ b/examples/standalone-web-bundle/README.md
@@ -1,6 +1,6 @@
-# Dist Bundle Example
+# Standalone Web Bundle Example
 
-This example shows how to embed wsdl-web in a plain HTML page using the prebuilt dist bundle.
+This example shows how to embed wsdl-web in a plain HTML page using the standalone web bundle.
 
 ## Setup
 
@@ -15,14 +15,14 @@ This example shows how to embed wsdl-web in a plain HTML page using the prebuilt
 2. Copy the build output into this directory:
 
    ```bash
-   cp dist-standalone/wsdl-web.js examples/dist-bundle/
-   cp dist-standalone/wsdl-web.css examples/dist-bundle/
+   cp dist-standalone/wsdl-web.js examples/standalone-web-bundle/
+   cp dist-standalone/wsdl-web.css examples/standalone-web-bundle/
    ```
 
 3. Open `index.html` in your browser — or serve it with any static file server:
 
    ```bash
-   npx serve examples/dist-bundle
+   npx serve examples/standalone-web-bundle
    ```
 
 ## What It Does
@@ -31,4 +31,4 @@ The example mounts wsdl-web with a pre-configured WSDL URL and hides the URL inp
 
 ## Documentation
 
-See the full documentation: [Embedding with the Dist Bundle](../../docs/embedding-dist-bundle.md)
+See the full documentation: [Embedding with the Standalone Web Bundle](../../docs/embedding-standalone-web-bundle.md)

--- a/examples/standalone-web-bundle/index.html
+++ b/examples/standalone-web-bundle/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WSDL Web — Dist Bundle Example</title>
+    <title>WSDL Web — Standalone Web Bundle Example</title>
 
     <!--
       Copy wsdl-web.js and wsdl-web.css from the dist-standalone/ build output

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ nav:
       - Copy as cURL: copy-as-curl.md
       - WSDL documentation: wsdl-documentation.md
   - Embedding:
-      - Dist bundle: embedding-dist-bundle.md
+      - Standalone web bundle: embedding-standalone-web-bundle.md
       - npm package: embedding-npm-package.md
   - Docker: docker.md
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export interface WsdlSpec {
 /**
  * Configuration options for the embeddable WsdlWeb component.
  *
- * These options work identically whether you use the prebuilt dist bundle
+ * These options work identically whether you use the standalone web bundle
  * (`WsdlWeb.init()`) or the React component (`<WsdlWeb />`).
  */
 export interface WsdlWebConfig {

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -1,5 +1,5 @@
 /**
- * Standalone entry point for the prebuilt dist bundle.
+ * Standalone web bundle entry point.
  *
  * Exposes `WsdlWeb.init(domNode, config)` on the global `window` object
  * so users can embed wsdl-web in any HTML page without a build step.

--- a/vite.config.standalone.ts
+++ b/vite.config.standalone.ts
@@ -4,12 +4,15 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 /**
- * Vite config for the standalone (prebuilt) dist bundle.
+ * Vite config for the standalone web bundle.
  * Produces a single JS file that can be loaded via <script> tag.
  */
 export default defineConfig({
   base: './',
   plugins: [react(), tailwindcss()],
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
Rename all references to "dist bundle" or "prebuilt dist bundle" to "standalone web bundle" throughout the codebase for clarity and consistency.

## Key Changes
- Renamed example directory from `examples/dist-bundle/` to `examples/standalone-web-bundle/`
- Updated all documentation files to use "standalone web bundle" terminology:
  - `docs/embedding-dist-bundle.md` → `docs/embedding-standalone-web-bundle.md`
  - Updated references in `README.md`, `docs/README.md`, and `mkdocs.yml`
- Updated code comments in:
  - `vite.config.standalone.ts` — clarified config purpose
  - `src/config.ts` — updated WsdlWebConfig documentation
  - `src/standalone.tsx` — updated entry point comment
- Updated CI workflow step name in `.github/workflows/ci.yml`
- Updated example HTML title and setup instructions
- Added `process.env.NODE_ENV` definition to Vite config for production builds

## Notable Details
The terminology change improves clarity by distinguishing this as a "standalone web bundle" (a self-contained distribution for embedding) rather than a generic "dist bundle" (which could refer to any build output). All user-facing documentation, code comments, and file paths have been updated consistently.